### PR TITLE
Limit inspector in default loop only. To avoid it crash the default l…

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -4768,7 +4768,10 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
 
   v8_platform.DrainVMTasks(isolate);
   v8_platform.CancelVMTasks(isolate);
-  WaitForInspectorDisconnect(&env);
+  // Together with the above temp work around, temp fix the destructor.
+  if (env.event_loop() == uv_default_loop()) {
+    WaitForInspectorDisconnect(&env);
+  }
 #if defined(LEAK_SANITIZER)
   __lsan_do_leak_check();
 #endif

--- a/src/node.cc
+++ b/src/node.cc
@@ -4715,11 +4715,13 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   uv_key_set(&thread_local_env, &env);
   env.Start(argc, argv, exec_argc, exec_argv, v8_is_profiling);
 
-  const char* path = argc > 1 ? argv[1] : nullptr;
-  StartInspector(&env, path, debug_options);
+  if (env.event_loop() == uv_default_loop()) {
+    const char* path = argc > 1 ? argv[1] : nullptr;
+    StartInspector(&env, path, debug_options);
 
-  if (debug_options.inspector_enabled() && !v8_platform.InspectorStarted(&env))
-    return 12;  // Signal internal error.
+    if (debug_options.inspector_enabled() && !v8_platform.InspectorStarted(&env))
+      return 12;  // Signal internal error.
+  }
 
   env.set_abort_on_uncaught_exception(abort_on_uncaught_exception);
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -4715,6 +4715,7 @@ inline int Start(Isolate* isolate, IsolateData* isolate_data,
   uv_key_set(&thread_local_env, &env);
   env.Start(argc, argv, exec_argc, exec_argv, v8_is_profiling);
 
+  // TODO: temperal work around crashing before we dive into inspector.
   if (env.event_loop() == uv_default_loop()) {
     const char* path = argc > 1 ? argv[1] : nullptr;
     StartInspector(&env, path, debug_options);


### PR DESCRIPTION
…oop's async handle queue

when inspector created in other node isolation.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
